### PR TITLE
Testing the use of grid to align the logos properly

### DIFF
--- a/epubcheck_fundraising_test.html
+++ b/epubcheck_fundraising_test.html
@@ -30,19 +30,47 @@
                 align-items: center;
             }
             #logos1 {
+                grid-template-areas: "daisy publizon wiley hachette";
                 grid-template-columns: 1fr 1fr 2fr 3fr;
             }
             #logos2 {
+                grid-template-areas: "learning voyager norton lumina blank1 blank2 blank3";
                 grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
             }
-            .box {
-                border-radius: 5px;
-                border: 1pt solid black;
-                padding: 20px;
+            #daisy {
+                grid-area: daisy;
+            }
+            #publizon {
+                grid-area: publizon;
+            }
+            #wiley {
+                grid-area: wiley;
+            }
+            #hachette {
+                grid-area: hachette;
             }
 
-
-
+            #learning {
+                grid-area: learning;
+            }
+            #voyager {
+                grid-area: voyager;
+            }
+            #norton {
+                grid-area: norton;
+            }
+            #lumina {
+                grid-area: lumina;
+            }
+            #blank1 {
+                grid-area: blank1;
+            }
+            #blank2 {
+                grid-area: blank2;
+            }
+            #blank3 {
+                grid-area: blank3;
+            }
         </style>
     </head>
     <body id="www-w3-org" class="w3c_public">
@@ -211,60 +239,38 @@
 				<h5>Logos</h5>
 
                 <div class="logos" id="logos1">
-                    <div class="box">
-                        <svg viewBox="0 0 858 765">
-                            <title>DAISY Consortium Logo</title>
-                            <image href="donators_logos/daisy_high.jpg" width="858" height="765"/>
-                        </svg>
+                    <div class="box" id="daisy">
+                        <img src="donators_logos/daisy_high.jpg" width="100%" height="auto" alt="DAISY Consortium Logo"/>
                     </div>
-                    <div class="box">
-                        <svg viewBox="0 0 591 158">
-                            <title>Publizon Logo</title>
-                            <image href="donators_logos/publizon-logo.jpg" width="591" height="158"/>
-                        </svg>
+                    <div class="box" id="publizon">
+                        <img src="donators_logos/publizon-logo.jpg" width="100%" height="auto" alt="Publizon Logo"/>
                     </div>
-                    <div class="box">
-                        <svg viewBox="0 0 576 231">
-                            <title>Wiley Logo</title>
-                            <image href="donators_logos/Wiley_Wordmark_black.png" width="576" height="231"/>
-                        </svg>
+                    <div class="box" id="wiley">
+                        <img src="donators_logos/Wiley_Wordmark_black.png" width="100%" height="auto" alt="Wiley Logo"/>
                     </div>
-                    <div class="box">
-                        <svg viewBox="0 0 1885 606">
-                            <title>Hachette Logo</title>
-                            <image href="donators_logos/Hachette%20Livre.jpg" width="1885" height="606"/>
-                        </svg>
+                    <div class="box" id="hachette">
+                        <img src="donators_logos/Hachette%20Livre.jpg" width="100%" height="auto" alt="Hachette Logo"/>
                     </div>
                 </div>
+
                 <div class="logos" id="logos2">
-                    <div class="box">
-                        <title>Learning Mate Logo</title>
-                        <svg viewBox="0 0 2354 417">
-                            <image href="donators_logos/LearningMate%20Logo.png" width="2354" height="417"/>
-                        </svg>
+                    <div class="box" id="learning">
+                        <img src="donators_logos/LearningMate%20Logo.png" width="100%" height="auto" alt="Learning Mate Logo"/>
                     </div>
-                    <div class="box">
-                        <svg viewBox="0 0 478 512">
-                            <title>Voyager Japan Logo</title>
-                            <image href="donators_logos/rectangle_VJstar_logo_512.jpg" width="478" height="512"/>
-                        </svg>
+                    <div class="box" id="voyager">
+                        <img src="donators_logos/rectangle_VJstar_logo_512.jpg" width="100%" height="auto" alt="Voyager Japan Logo"/>
                     </div>
-                    <div class="box">
-                        <svg viewBox="0 0 1800 545">
-                            <title>W. W. Norton Logo</title>
-                            <image href="donators_logos/NortonLogo_notagline.jpg" width="1800" height="545"/>
-                        </svg>
+                    <div class="box" id="norton">
+                        <img src="donators_logos/NortonLogo_notagline.jpg" width="100%" height="auto" alt="W. W. Norton Logo"/>
                     </div>
-                    <div class="box">
-                        <svg viewBox="0 0 2482 1750">
-                            <title>Lumina Datamatics Logo</title>
-                            <image href="donators_logos/Datamatics_logo.jpg" width="2482" height="1750"/>
-                        </svg>
+                    <div class="box" id="lumina">
+                        <img src="donators_logos/Datamatics_logo.jpg" width="100%" height="auto" alt="Lumina Datamatics Logo"/>
                     </div>
-                    <div> </div>
-                    <div> </div>
-                    <div> </div>
+                    <div id="blank1"> </div>
+                    <div id="blank2"> </div>
+                    <div id="blank3"> </div>
                 </div>
+                
                 
 
                 <h4>

--- a/epubcheck_fundraising_test.html
+++ b/epubcheck_fundraising_test.html
@@ -23,6 +23,26 @@
                 list-style: disc inside;
             }
 
+            .logos {
+                display: grid;
+                grid-gap: 10px;
+                justify-items: center;
+                align-items: center;
+            }
+            #logos1 {
+                grid-template-columns: 1fr 1fr 2fr 3fr;
+            }
+            #logos2 {
+                grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+            }
+            .box {
+                border-radius: 5px;
+                border: 1pt solid black;
+                padding: 20px;
+            }
+
+
+
         </style>
     </head>
     <body id="www-w3-org" class="w3c_public">
@@ -189,31 +209,65 @@
 				    <li>Vitalsource</li>
                 </ul>
 				<h5>Logos</h5>
-				<div>
-				<img src="donators_logos/daisy_high.jpg" alt="DAISY Consortium logo" width="100"/>
-				</div>
-				<div>
-				<img src="donators_logos/publizon-logo.jpg" alt="Publizon logo" width="100"/>
-				</div>
-				<div>
-				<img src="donators_logos/Wiley_Wordmark_black.png" alt="Wiley logo" width="200"/>
-				</div>
-				<div>
-				<img src="donators_logos/Hachette%20Livre.jpg" alt="Hachette Livre logo" width="300"/>
-				</div>
-				<div>
-				<img src="donators_logos/LearningMate%20Logo.png" alt="LearningMate logo" width="100"/>
-				</div>
-				<div>
-				<img src="donators_logos/rectangle_VJstar_logo_512.jpg" alt="Voyager Japan logo" width="100"/>
-				</div>
-				<div>
-				<img src="donators_logos/NortonLogo_notagline.jpg" alt="W.W. Norton logo" width="100"/>
-				</div>
-				<div>
-				<img src="donators_logos/Datamatics_logo.jpg" alt="Lumina Datamatics logo" width="100"/>
-				</div>
-                            <h4>
+
+                <div class="logos" id="logos1">
+                    <div class="box">
+                        <svg viewBox="0 0 858 765">
+                            <title>DAISY Consortium Logo</title>
+                            <image href="donators_logos/daisy_high.jpg" width="858" height="765"/>
+                        </svg>
+                    </div>
+                    <div class="box">
+                        <svg viewBox="0 0 591 158">
+                            <title>Publizon Logo</title>
+                            <image href="donators_logos/publizon-logo.jpg" width="591" height="158"/>
+                        </svg>
+                    </div>
+                    <div class="box">
+                        <svg viewBox="0 0 576 231">
+                            <title>Wiley Logo</title>
+                            <image href="donators_logos/Wiley_Wordmark_black.png" width="576" height="231"/>
+                        </svg>
+                    </div>
+                    <div class="box">
+                        <svg viewBox="0 0 1885 606">
+                            <title>Hachette Logo</title>
+                            <image href="donators_logos/Hachette%20Livre.jpg" width="1885" height="606"/>
+                        </svg>
+                    </div>
+                </div>
+                <div class="logos" id="logos2">
+                    <div class="box">
+                        <title>Learning Mate Logo</title>
+                        <svg viewBox="0 0 2354 417">
+                            <image href="donators_logos/LearningMate%20Logo.png" width="2354" height="417"/>
+                        </svg>
+                    </div>
+                    <div class="box">
+                        <svg viewBox="0 0 478 512">
+                            <title>Voyager Japan Logo</title>
+                            <image href="donators_logos/rectangle_VJstar_logo_512.jpg" width="478" height="512"/>
+                        </svg>
+                    </div>
+                    <div class="box">
+                        <svg viewBox="0 0 1800 545">
+                            <title>W. W. Norton Logo</title>
+                            <image href="donators_logos/NortonLogo_notagline.jpg" width="1800" height="545"/>
+                        </svg>
+                    </div>
+                    <div class="box">
+                        <svg viewBox="0 0 2482 1750">
+                            <title>Lumina Datamatics Logo</title>
+                            <image href="donators_logos/Datamatics_logo.jpg" width="2482" height="1750"/>
+                        </svg>
+                    </div>
+                    <div> </div>
+                    <div> </div>
+                    <div> </div>
+                </div>
+                
+
+                <h4>
                                 Organization Background
                             </h4>
 				<p>

--- a/test.html
+++ b/test.html
@@ -10,11 +10,48 @@
             align-items: center;
         }
         #logos1 {
+            grid-template-areas: "daisy publizon wiley hachette";
             grid-template-columns: 1fr 1fr 2fr 3fr;
         }
         #logos2 {
+            grid-template-areas: "learning voyager norton lumina blank1 blank2 blank3";
             grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
         }
+        #daisy {
+            grid-area: daisy;
+        }
+        #publizon {
+            grid-area: publizon;
+        }
+        #wiley {
+            grid-area: wiley;
+        }
+        #hachette {
+            grid-area: hachette;
+        }
+
+        #learning {
+            grid-area: learning;
+        }
+        #voyager {
+            grid-area: voyager;
+        }
+        #norton {
+            grid-area: norton;
+        }
+        #lumina {
+            grid-area: lumina;
+        }
+        #blank1 {
+            grid-area: blank1;
+        }
+        #blank2 {
+            grid-area: blank2;
+        }
+        #blank3 {
+            grid-area: blank3;
+        }
+        /* Only for testing */
         .box {
             border-radius: 5px;
             border: 1pt solid black;
@@ -24,59 +61,35 @@
 </head>
 <body>
     <div class="logos" id="logos1">
-        <div class="box">
-            <svg viewBox="0 0 858 765">
-                <title>DAISY Consortium Logo</title>
-                <image href="donators_logos/daisy_high.jpg" width="858" height="765"/>
-            </svg>
+        <div class="box" id="daisy">
+            <img src="donators_logos/daisy_high.jpg" width="100%" height="auto" alt="DAISY Consortium Logo"/>
         </div>
-        <div class="box">
-            <svg viewBox="0 0 591 158">
-                <title>Publizon Logo</title>
-                <image href="donators_logos/publizon-logo.jpg" width="591" height="158"/>
-            </svg>
+        <div class="box" id="publizon">
+            <img src="donators_logos/publizon-logo.jpg" width="100%" height="auto" alt="Publizon Logo"/>
         </div>
-        <div class="box">
-            <svg viewBox="0 0 576 231">
-                <title>Wiley Logo</title>
-                <image href="donators_logos/Wiley_Wordmark_black.png" width="576" height="231"/>
-            </svg>
+        <div class="box" id="wiley">
+            <img src="donators_logos/Wiley_Wordmark_black.png" width="100%" height="auto" alt="Wiley Logo"/>
         </div>
-        <div class="box">
-            <svg viewBox="0 0 1885 606">
-                <title>Hachette Logo</title>
-                <image href="donators_logos/Hachette%20Livre.jpg" width="1885" height="606"/>
-            </svg>
+        <div class="box" id="hachette">
+            <img src="donators_logos/Hachette%20Livre.jpg" width="100%" height="auto" alt="Hachette Logo"/>
         </div>
     </div>
     <div class="logos" id="logos2">
-        <div class="box">
-            <title>Learning Mate Logo</title>
-            <svg viewBox="0 0 2354 417">
-                <image href="donators_logos/LearningMate%20Logo.png" width="2354" height="417"/>
-            </svg>
+        <div class="box" id="learning">
+            <img src="donators_logos/LearningMate%20Logo.png" width="100%" height="auto" alt="Learning Mate Logo"/>
         </div>
-        <div class="box">
-            <svg viewBox="0 0 478 512">
-                <title>Voyager Japan Logo</title>
-                <image href="donators_logos/rectangle_VJstar_logo_512.jpg" width="478" height="512"/>
-            </svg>
+        <div class="box" id="voyager">
+            <img src="donators_logos/rectangle_VJstar_logo_512.jpg" width="100%" height="auto" alt="Voyager Japan Logo"/>
         </div>
-        <div class="box">
-            <svg viewBox="0 0 1800 545">
-                <title>W. W. Norton Logo</title>
-                <image href="donators_logos/NortonLogo_notagline.jpg" width="1800" height="545"/>
-            </svg>
+        <div class="box" id="norton">
+            <img src="donators_logos/NortonLogo_notagline.jpg" width="100%" height="auto" alt="W. W. Norton Logo"/>
         </div>
-        <div class="box">
-            <svg viewBox="0 0 2482 1750">
-                <title>Lumina Datamatics Logo</title>
-                <image href="donators_logos/Datamatics_logo.jpg" width="2482" height="1750"/>
-            </svg>
+        <div class="box" id="lumina">
+            <img src="donators_logos/Datamatics_logo.jpg" width="100%" height="auto" alt="Lumina Datamatics Logo"/>
         </div>
-        <div> </div>
-        <div> </div>
-        <div> </div>
+        <div id="blank1"> </div>
+        <div id="blank2"> </div>
+        <div id="blank3"> </div>
     </div>
 </body>
 </html>

--- a/test.html
+++ b/test.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test</title>
+    <style>
+        .logos {
+            display: grid;
+            grid-gap: 10px;
+            justify-items: center;
+            align-items: center;
+        }
+        #logos1 {
+            grid-template-columns: 1fr 1fr 2fr 3fr;
+        }
+        #logos2 {
+            grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+        }
+        .box {
+            border-radius: 5px;
+            border: 1pt solid black;
+            padding: 20px;
+        }
+    </style>
+</head>
+<body>
+    <div class="logos" id="logos1">
+        <div class="box">
+            <svg viewBox="0 0 858 765">
+                <title>DAISY Consortium Logo</title>
+                <image href="donators_logos/daisy_high.jpg" width="858" height="765"/>
+            </svg>
+        </div>
+        <div class="box">
+            <svg viewBox="0 0 591 158">
+                <title>Publizon Logo</title>
+                <image href="donators_logos/publizon-logo.jpg" width="591" height="158"/>
+            </svg>
+        </div>
+        <div class="box">
+            <svg viewBox="0 0 576 231">
+                <title>Wiley Logo</title>
+                <image href="donators_logos/Wiley_Wordmark_black.png" width="576" height="231"/>
+            </svg>
+        </div>
+        <div class="box">
+            <svg viewBox="0 0 1885 606">
+                <title>Hachette Logo</title>
+                <image href="donators_logos/Hachette%20Livre.jpg" width="1885" height="606"/>
+            </svg>
+        </div>
+    </div>
+    <div class="logos" id="logos2">
+        <div class="box">
+            <title>Learning Mate Logo</title>
+            <svg viewBox="0 0 2354 417">
+                <image href="donators_logos/LearningMate%20Logo.png" width="2354" height="417"/>
+            </svg>
+        </div>
+        <div class="box">
+            <svg viewBox="0 0 478 512">
+                <title>Voyager Japan Logo</title>
+                <image href="donators_logos/rectangle_VJstar_logo_512.jpg" width="478" height="512"/>
+            </svg>
+        </div>
+        <div class="box">
+            <svg viewBox="0 0 1800 545">
+                <title>W. W. Norton Logo</title>
+                <image href="donators_logos/NortonLogo_notagline.jpg" width="1800" height="545"/>
+            </svg>
+        </div>
+        <div class="box">
+            <svg viewBox="0 0 2482 1750">
+                <title>Lumina Datamatics Logo</title>
+                <image href="donators_logos/Datamatics_logo.jpg" width="2482" height="1750"/>
+            </svg>
+        </div>
+        <div> </div>
+        <div> </div>
+        <div> </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
@laudrain 

I have tried to see if, by using grids, it is possible to make a better alignments of the logos while 

- allowing them to rescale for smaller screens
- respecting the size differences as described in the text

I have a `test.html` file which shows the bare structure, and an `epubcheck_fundraising_test.html` incorporating the tricks into the fundraising file. Check if it looks better for you, and if you can leave with that: it would require a careful adjustment of the content including the style part if a new entry comes in. 