### PR TITLE
Activity home page update

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
         <script src="js/jquery.timer.js"></script>
 	    <script src="js/dpub-common.js"></script>
         <script src="js/dpub.js"></script>
-        <script src="js/testimonials.js"></script>
         <style type="text/css">
             .logo {float: left;}
             .cf{clear:both;}
@@ -82,12 +81,18 @@
                         <a class="imageLink" href="https://player.streamfizz.live/embed/media/ckd4x46to1l2707728urrm98a"> <img src="home-page-imgs/Webinar2020.png" alt="Screenshot of the W3C Publishing Community Webinar, July 2020" width="100">W3C Publishing Community Webinar, July 2020.</a>
                     </p>
 
-                    <h3 class="category"> <span class="ribbon"><b>Presentations</b></span></h3>
+                    <br>
+                    
+                    <h3 class="category"  style="text-align: left"><span class="ribbon"><b>Presentations</b></span></h3>
                     <p>(See also <a href="events.html#presentations">complete list</a>)</p>
-
                     <!-- The content below is filled in through the dpub.js script -->
-                    <ul class="theme" id="presentations">
-                    </ul>
+                    <ul class="theme" id="presentations"></ul>
+
+ 
+                    <h3 class="category"><span class="ribbon"><b>Upcoming Events with W3C Participation</b></span></h3>
+                    <p>(See also <a href="events.html#events">complete list</a>)</p>
+                    <ul class="theme" id="futureevents"></ul>
+
                 </nav>
 
                 <!-- The top level menu -->
@@ -111,47 +116,44 @@
                         <!-- This block is the main content in the middle of the page -->
                         <div class="unit size2on3" id="maincol">
                             <section id="w3c_content_body" class="hyphenate">
-                            
                                 <p>
-                                    The web was created to provide access to a “<a href="http://info.cern.ch/hypertext/WWW/TheProject.html">universe of documents</a>.” Since then, the Web has become many things, but documents and, by extension, publications, have remained close to the heart of the Web.
-                                </p>
+                                    Publishing@W3C is the Activity under which the specifically publishing-related groups in the W3C are organized: two Working Groups, two Community Groups, and a Business Group.
 
+                                </p>    
+                                <h2 class="cf">The Working Groups</h2>
+                                
                                 <p>
-                                    Many publishers use EPUB to bring digital content to their readers. EPUB is built from Web technologies, but publishing uses the Web for so much more, from everyday matters of communication and marketing to learning management systems and online journals. Print and digital books are bought and sold on websites.
+                                    Working Groups are where formal W3C standards, called Recommendations, are developed and maintained. They have detailed charters spelling out the work they have agreed to do and the timeline for its completion. Participants, typically technical people, are from organizations that are <a href="https://www.w3.org/Consortium/membership.html">regular members of the W3C</a> and that agree not to assert any patent claims on their contributions. There are two Working Groups in the Publishing@W3C Activity.
                                 </p>
                                 
                                 <p>
-                                    But publications are still not first-class citizens of the web. EPUB exists in silos, somewhat disconnected from the Web. Long texts make special demands on readers. We expect to read books and publications even while offline. We hope to share publications, save them, keep them. We expect a kind of permanence to publications, which we don’t typically expect of Web sites.
+                                    The <a href="https://www.w3.org/publishing/groups/epub-wg/">EPUB 3 Working Group</a> is developing and maintaining the EPUB&nbsp;3 family of specifications, with a focus on bringing <a href="https://www.w3.org/TR/epub-overview-33/">EPUB&nbsp;3.3</a> to formal W3C Recommendation status. Important aspects of that work include restructuring and clarifying the specification and developing a proper testing environment to improve reading system interoperability. Its charter explicitly requires that EPUB&nbsp;3.3 must be backwards-compatible with EPUB&nbsp;3.2. <a href="https://www.w3.org/TR/epub-a11y-11/">EPUB Accessibility&nbsp;1.1</a> is also being taken to Recommendation status by this Working Group. Links to current drafts of EPUB&nbsp;3.3, EPUB Accessibility&nbsp;1.1, and related specifications are available at the <a href="https://www.w3.org/publishing/groups/epub-wg/PublStatus">group’s publication status page</a>, along with a wealth of other information about this work.
                                 </p>
                                 
                                 <p>
-                                    Publishing at W3C works to identify and solve problems. We also want EPUB to be truly interoperable among readers. We also want publications on the Web to be more capable, more beautiful, more accessible, and easier. 
+                                    The <a href="https://www.w3.org/publishing/groups/publ-wg/">Audiobooks Working Group</a> is chartered to maintain the <a href="https://www.w3.org/TR/audiobooks/">Audiobooks</a> Recommendation, and the <a href="https://www.w3.org/TR/pub-manifest/">Publication Manifest</a> Recommendations on which it is based, as well as fostering and advancing the standardization of audiobooks for the industry.
                                 </p>
-							
-                                <h2 class="cf">How to Participate</h2>
-
+                                
+                                <h2 class=cf>The Community Groups</h2>
+                                
                                 <p>
-                                    The focal point of general conversations for the future of publishing takes place in the <a href="https://www.w3.org/publishing/groups/publ-bg/">Publishing Business Group</a>; to join the Group, please go to the Group’s page to sign up. Participation in this group requires a modest fee. 
+                                    <a href="https://www.w3.org/community/about/#cg">Community Groups</a> are where ideas are incubated in the W3C. They do not operate under the formal constraints of Working Groups. They’re open to anybody, not requiring membership in the W3C or adhering to the patent policy required for Working Groups. Community Groups serve an essential role in trying out new ideas and demonstrating the need for a current or future Working Group to advance successful technologies with a proven need to Recommendation status.
                                 </p>
                                 
                                 <p>
-                                    The present and future of EPUB lies by the <a href="https://www.w3.org/publishing/groups/epub-wg/">EPUB 3 Working Group</a>. This group works on ensuring the interoperability of EPUB; it is also the home for the technical evolution of EPUB 3 while maintaining a strong backward compatibility and taking into account the business needs of the publishing community. Participation in that group requires to be a regular W3C member; to join that group, please <a href="https://www.w3.org/2004/01/pp-impl/125377/join">sign up here</a>.  
+                                    The <a href="https://www.w3.org/community/publishingcg/">Publishing Community Group</a> is the incubation zone for the <a href="https://w3c.github.io/publishing/">Publishing@W3C Activity</a>. It currently has task forces working on accessibility for fixed layout EPUBs and on developing comprehensive documentation for EPUB. New ideas about EPUB should be brought to the CG. Another Community Group is working on <a href="https://www.w3.org/community/sync-media-pub/">Synchronized Multimedia for Publications</a>.
                                 </p>
-
+                                
+                                <h2 class=cf>The Publishing Business Group</h2>
+                                
                                 <p>
-                                    The EPUB 3 Working Group is closely related to the <a href="http://www.w3.org/community/publishingcg/">Publishing Community Group</a>. While the EPUB 3 Working Group is the guardian of the EPUB standard, the Community Group is the home for discussions around new technical directions, ideas, and experimentation; some of these ideas may become part of a future EPUB or other standards. It is the primary “incubation arm” or the of Publishing@W3C, the birthplace of new ideas for the future. We encourage you to join the new <a href="http://www.w3.org/community/publishingcg/">EPUB 3 Community Group</a> which is free and open to all. Simply go there to sign up.
+                                    The <a href="https://www.w3.org/publishing/groups/publ-bg/">Publishing Business Group</a> is for people and organizations across the publishing spectrum to support the <a href="https://w3c.github.io/publishing/">Publishing@W3C Activity</a> by informing the Working Groups and Community Groups about needs and priorities, and by raising funds for the development of important resources like <a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a>. Its members are primarily from the business side of publishing-related organizations, rather than highly technical staff. Because membership in a Business Group does not include the ability to participate in Working Groups, the dues are less than those for a full membership in the W3C.
                                 </p>
-
+                                
+                                <h2 class=cf>Other Related Work of Interest</h2>
+                                
                                 <p>
-                                    The Publishing@W3C activity has also developed, over the past years, a separate <a href="https://www.w3.org/TR/audiobooks/">Audiobooks</a> standard in a separate Working Group, namely the <a href="https://www.w3.org/publishing/groups/publ-wg/">Audiobooks (formerly Publishing) Working Group</a>. This <a href="https://www.w3.org/TR/audiobooks/">specification</a> (published in 2020) offers the first International Standard to produce and distribute audiobooks in an interoperable manner. The structure of the specification, relying on the more general <a href="https://www.w3.org/TR/pub-manifest/">Publication Manifest</a> specification, can also be re-used for the possible future developments of other, specialized forms of publications, like Mangas (or other forms of visual narratives).
-                                </p>
-
-                                <p> 
-                                    The activity has also set up some other Community Groups to concentrate on specific issues. The activity will watch the progress of work in these Community Groups and take it into consideration as appropriate. See the side bar for the list of those. There are also a number of other community groups, set up by the community at large, whose topics may be relevant to publishing; see the <a href="https://www.w3.org/community/">W3C Community Groups’</a> page for further details. All these groups are free and open for all.
-                                </p>
-
-                                <p>
-                                    The regular W3C membership also covers the possible participation in any Business Groups, including the Publishing Business Group, but also any other Interest or Working Groups at W3C.  To become a W3C member, please write to <a href="mailto:membership@w3.org">membership@w3.org</a> for more information.
+                                    In addition to the work of the <a href="https://w3c.github.io/publishing/">Publishing@W3C Activity</a>, people working in the publishing industry are also often interested in the work of other areas in the W3C, such as <a href="https://www.w3.org/Style/CSS/">Cascading Style Sheets (CSS)</a>, the <a href="https://www.w3.org/WAI/">Web Accessibility Initiative</a>, among others. Participation in Interest and Working Groups is open to regular members of W3C.
                                 </p>
 
                                 <h2>Latest News</h2>
@@ -160,58 +162,12 @@
 
                                 </div>
 
-                                <h2>Other W3C Groups Relevant for Publishing</h2>
                                 <p>
-                                    There are many areas of technical work at W3C in which the publishing community is already participating. Among these are the <a href="https://www.w3.org/Style/CSS/">CSS Working Group</a>, or various groups in the <a href="https://www.w3.org/standards/webdesign/accessibility">Web Accessibility Initiative</a>. Participation in Interest and Working Groups is open to regular members of W3C.
-                                </p>
-                                <p>
-                                    There are a number of groups working on technologies that will also be of interest and the publishing roadmap evolves including Video, Audio, Graphics, Web Payments to name a few.
-                                </p>
-
-                                <p>
-                                    <strong>Questions?</strong> <a href="mailto:ivan@w3.org">Ivan Herman</a>, &lt;ivan@w3.org&gt;, Publishing@W3C Technical Lead.
-                                    This page is served from GitHub; comments and suggestions on the page can also be made via the <a href="https://github.com/w3c/publishing/issues">GitHub issues’</a> list.
+                                    <strong>Questions?</strong> <a href="mailto:ivan@w3.org">Ivan Herman</a>, &lt;ivan@w3.org&gt;, Publishing@W3C Technical Lead. This page is served from GitHub; comments and suggestions on the page can also be made via the <a href="https://github.com/w3c/publishing/issues">GitHub issues’</a> list.
                                 </p>
                             </section>
-                          <!-- <section id="about" class="hyphenate"><br>
-                          </section> -->
                         </div>
 
-                        <!-- Right column; most of the content there are generated -->
-                        <div class="unit size1on3 lastUnit" id="secondcol">
-                            <div class="infobar bPadding">
-                                <h3>Upcoming Events with W3C Participation</h3>
-                                <p>(See also <a href="events.html#events">complete list</a>)</p>
-                                <!-- This list is filled through the dpub.js script -->
-                                <ul class="theme" id="futureevents">
-                                </ul>
-                            </div>
-
-                            <!-- This block is filled through the feed.js script -->
-                            <!-- <div class="infobar bPadding" id="dpubRss">
-                                <h3><a href="http://www.w3.org/blog/dpub/">Meeting Summaries</a></h3>
-                                <p style="font-size:90%">See <a href="http://www.w3.org/blog/dpub/">all summaries</a> for details and older items</p>
-                            </div> -->
-
-                            <!-- This block is filled through the testimonials.js script -->
-                            <div class="infobar bPadding" id="testimonials">
-
-                                <!-- The buttons that control the display of the testimonials -->
-	                            <div id="reel-control" role="application" aria-roledescription="Buttons to control the display of testimonials">
-                                   <img id="pre_button" src="home-page-imgs/previous.png" alt="arrow to the left" role="button" aria-roledescription="Stop the automatic reel and switch to the previous testimonial"/>
-	                               <img id="pause_button" src="home-page-imgs/pause.png" alt="circle or double arrow to the right" role="switch" aria-checked="true" aria-roledescription="When checked, testimonials change automatically; when unchecked, use the next or previous action to move"/>
-	                               <img id="next_button" src="home-page-imgs/next.png" alt="arrow to the right" role="button" aria-roledescription="Stop the automatic reel and switch to the next testimonial"/>
-	                            </div>
-
-                                <h3>Industry testimonials</h3>
-                                <div id="quoteblock-inner" role="marquee" aria-roledescription="Display of testimonials; by default, changing automatically">
-                                    <div id="quoteblock-quote">
-                                        <blockquote id="quoteblock-tag-quote" class="hyphenate" ></blockquote>
-                                    </div>
-                                    <div id="quoteblock-attribution"><span id="quoteblock-tag-attribution"></span></div>
-                                </div>
-                            </div>
-                        </div>
                     </div><!-- /end class line -->
                 </div><!-- /end #w3c_mainCol -->
             </main><!-- /end #w3c_main -->

--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
         <script src="https://www.w3.org/scripts/jquery/2.1/jquery.min.js"></script>
         <script src="js/feed.js"></script>
         <script src="js/hyphenate.min.js"></script>
-        <script src="js/jquery.timer.js"></script>
 	    <script src="js/dpub-common.js"></script>
         <script src="js/dpub.js"></script>
         <style type="text/css">
@@ -68,12 +67,12 @@
                     <h3 class="category"><span class="ribbon"><b>Active Groups, Resources</b></span></h3>
                     <ul class="theme">
                         <li><object data="https://www.w3.org/publishing/logo/logo.svg" style="width:65%" type="image/svg+xml"></object>
-                        <li><a href="https://www.w3.org/publishing/groups/publ-bg/">Publishing Business Group</a></li>
                         <li><a href="https://www.w3.org/publishing/groups/epub-wg/">EPUB 3 Working Group</a></li>
-                        <li><a href="http://www.w3.org/community/publishingcg/">Publishing Community Group</a></li>
                         <li><a href="https://www.w3.org/publishing/groups/publ-wg/">Audiobooks Working Group</a></li>
-                        <li><a href="http://www.w3.org/community/bdcomacg/">BD Comics Manga Community Group</a></li>
+                        <li><a href="http://www.w3.org/community/publishingcg/">Publishing Community Group</a></li>
                         <li><a href="http://www.w3.org/community/sync-media-pub/">Synchronized Multimedia for Publications Community Group</a></li>
+                        <li><a href="https://www.w3.org/publishing/groups/publ-bg/">Publishing Business Group</a></li>
+                        <!-- <li><a href="http://www.w3.org/community/bdcomacg/">BD Comics Manga Community Group</a></li> -->
                     </ul>
 
                     <h3 class="category"> <span class="ribbon"><b>Presentation Videos</b></span></h3>
@@ -118,8 +117,8 @@
                             <section id="w3c_content_body" class="hyphenate">
                                 <p>
                                     Publishing@W3C is the Activity under which the specifically publishing-related groups in the W3C are organized: two Working Groups, two Community Groups, and a Business Group.
-
                                 </p>    
+
                                 <h2 class="cf">The Working Groups</h2>
                                 
                                 <p>
@@ -157,6 +156,7 @@
                                 </p>
 
                                 <h2>Latest News</h2>
+                                
                                 <!-- This div is filled through the feed.js script -->
                                 <div id="mainRss">
 


### PR DESCRIPTION
Changes

- Right-hand column (including the testimonials) removed, with references to event participation moved to the left column
- Incorporated the text of BillK, with added links
- Reordered list of groups in the left menu to follow the same order as in the main text
- Minor housekeepings on the HTML sources


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publishing/pull/23.html" title="Last updated on Jul 6, 2021, 10:10 AM UTC (3d9cb1b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publishing/23/b3d6eec...3d9cb1b.html" title="Last updated on Jul 6, 2021, 10:10 AM UTC (3d9cb1b)">Diff</a>